### PR TITLE
docs: add CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -49,7 +49,7 @@ responsible for enforcement at:
 
 **atmuccio@users.noreply.github.com**
 
-All reports will be reviewed and investigated promptly and fairly. Community
+All reports will be reviewed and investigated fairly. Community
 leaders are obligated to respect the privacy and security of the reporter of
 any incident.
 


### PR DESCRIPTION
## Summary
- Adds CODE_OF_CONDUCT.md based on Contributor Covenant v2.1
- Sets enforcement contact to atmuccio@users.noreply.github.com
- Includes enforcement guidelines with graduated consequences

Closes #3

## Test plan
- [x] CODE_OF_CONDUCT.md exists at repo root
- [x] Based on Contributor Covenant v2.1
- [x] Enforcement contact information filled in
- [x] Attribution section with links to source

🤖 Generated with [Claude Code](https://claude.com/claude-code)