### PR TITLE
ci: add GitHub Pages deployment for demo app

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -1,0 +1,58 @@
+name: Deploy Demo
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build Demo
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build demo with base-href
+        run: npx nx build demo -- --base-href /Glint/
+
+      - name: Copy index.html to 404.html for SPA routing
+        run: cp dist/apps/demo/browser/index.html dist/apps/demo/browser/404.html
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist/apps/demo/browser
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/deploy-demo.yml` to deploy demo app on push to main
- Builds with `--base-href /Glint/` for GitHub Pages subdirectory hosting
- Copies `index.html` to `404.html` for SPA client-side routing support
- Uses GitHub Actions Pages deployment (configure-pages, upload-pages-artifact, deploy-pages)
- Supports manual trigger via workflow_dispatch

**Note**: GitHub Pages must be enabled in repo Settings with "GitHub Actions" as the source.

Closes #10

## Test plan
- [x] Workflow file is valid YAML
- [x] Build step includes `--base-href /Glint/`
- [x] 404.html is created for SPA routing
- [x] Demo will be available at `https://atmuccio.github.io/Glint/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)