### PR TITLE
ci: add npm publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,40 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    name: Build & Publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build library
+        run: npx nx build ui
+
+      - name: Verify package (dry run)
+        working-directory: dist/libs/ui
+        run: npm pack --dry-run
+
+      - name: Publish to npm
+        working-directory: dist/libs/ui
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/publish.yml` triggered on GitHub Release creation
- Builds library, runs `npm pack --dry-run` for verification, then publishes
- Uses `--provenance` for npm supply chain security
- Requires `NPM_TOKEN` secret to be configured in repo settings

**Prerequisites** (manual steps before first use):
- Create npm org and `NPM_TOKEN` (see #19)
- Package rename to final name (see #6)

Closes #11

## Test plan
- [x] Workflow file is valid YAML
- [x] Only triggers on Release published events
- [x] Includes dry-run verification before actual publish
- [x] Uses NPM_TOKEN secret for authentication

🤖 Generated with [Claude Code](https://claude.com/claude-code)