### PR TITLE
chore: update package.json metadata for npm

### DIFF
--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -1,6 +1,30 @@
 {
   "name": "@glint/ui",
   "version": "0.0.1",
+  "description": "Angular Style Zone UI component library — themeable components built on Angular CDK with signal-based cascading style customization",
+  "license": "MIT",
+  "author": "Anthony Muccio",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/atmuccio/Glint.git",
+    "directory": "libs/ui"
+  },
+  "homepage": "https://atmuccio.github.io/Glint",
+  "bugs": {
+    "url": "https://github.com/atmuccio/Glint/issues"
+  },
+  "keywords": [
+    "angular",
+    "ui",
+    "components",
+    "theming",
+    "style-zone",
+    "cdk",
+    "signals"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "peerDependencies": {
     "@angular/cdk": "^21.1.0",
     "@angular/common": "^21.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,12 @@
 {
   "name": "@glint/source",
   "version": "0.0.0",
+  "description": "Monorepo for the @glint/ui Angular component library and demo application",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/atmuccio/Glint.git"
+  },
   "scripts": {},
   "private": true,
   "dependencies": {


### PR DESCRIPTION
## Summary
- Adds npm metadata to `libs/ui/package.json`: description, author, repository, homepage, bugs, keywords, publishConfig
- Adds repository and description to root `package.json`
- Build verified: `npx nx build ui` passes
- Package name kept as `@glint/ui` pending rename (#6)

Closes #7

## Test plan
- [x] `libs/ui/package.json` has all required metadata fields
- [x] Root `package.json` has repository URL
- [x] `npx nx build ui` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)