### PR TITLE
docs: ConfirmDialog migration guide, demo coverage & shared styles

### DIFF
--- a/apps/demo/src/app/pages/accordion-demo.component.ts
+++ b/apps/demo/src/app/pages/accordion-demo.component.ts
@@ -60,20 +60,9 @@ import {
       </glint-accordion>
     </div>
   `,
+  host: { class: 'demo-page' },
   styles: `
     :host { display: block; }
-    h2 { margin-block: 0 0.25rem; font-size: 1.75rem; font-weight: 600; color: #1e293b; }
-    .page-desc { color: #64748b; margin-block: 0 2rem; font-size: 1.25rem; }
-    .demo-section {
-      background: white;
-      border: 1px solid #e2e8f0;
-      border-radius: 0.625rem;
-      padding: 2rem;
-      margin-block-end: 1.5rem;
-    }
-    .demo-section h3 { margin-block: 0 1rem; font-size: 1rem; font-weight: 600; color: #334155; }
-    .row { display: flex; gap: 0.75rem; flex-wrap: wrap; align-items: center; }
-    .stack { display: flex; flex-direction: column; gap: 1rem; }
   `,
 })
 export class AccordionDemoComponent {}

--- a/apps/demo/src/app/pages/advanced-inputs-demo.component.ts
+++ b/apps/demo/src/app/pages/advanced-inputs-demo.component.ts
@@ -24,22 +24,9 @@ import {
     GlintInputComponent,
     GlintKnobComponent,
   ],
+  host: { class: 'demo-page' },
   styles: `
     :host { display: block; }
-    h2 { margin-block: 0 0.25rem; font-size: 1.75rem; font-weight: 600; color: #1e293b; }
-    .page-desc { color: #64748b; margin-block: 0 2rem; font-size: 1.25rem; }
-    .demo-section {
-      background: white; border: 1px solid #e2e8f0; border-radius: 0.625rem;
-      padding: 2rem; margin-block-end: 1.5rem;
-    }
-    .demo-section h3 { margin-block: 0 1rem; font-size: 1rem; font-weight: 600; color: #334155; }
-    .row { display: flex; gap: 0.75rem; flex-wrap: wrap; align-items: center; }
-    .stack { display: flex; flex-direction: column; gap: 1rem; }
-    .output { margin-block-start: 1rem; padding: 0.75rem 1rem; background: #f8fafc;
-      border: 1px solid #e2e8f0; border-radius: 6px; font-size: 0.875rem; color: #64748b; }
-    .label-text {
-      margin-block: 0 0.25rem; font-size: 0.875rem; font-weight: 500; color: #475569;
-    }
     .knob-row { display: flex; gap: 2rem; flex-wrap: wrap; align-items: flex-start; }
     .knob-item { display: flex; flex-direction: column; align-items: center; gap: 0.5rem; }
   `,

--- a/apps/demo/src/app/pages/advanced-menus-demo.component.ts
+++ b/apps/demo/src/app/pages/advanced-menus-demo.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component, ChangeDetectionStrategy, signal } from '@angular/core';
 import {
   GlintTieredMenuComponent,
   GlintMenuBarComponent,
@@ -6,6 +6,7 @@ import {
   GlintContextMenuDirective,
   GlintDockComponent,
   GlintSpeedDialComponent,
+  GlintTabMenuComponent,
 } from '@glint-ng/core';
 import type { GlintMenuItem } from '@glint-ng/core';
 
@@ -20,17 +21,28 @@ import type { GlintMenuItem } from '@glint-ng/core';
     GlintContextMenuDirective,
     GlintDockComponent,
     GlintSpeedDialComponent,
+    GlintTabMenuComponent,
   ],
+  host: { class: 'demo-page' },
   template: `
     <h2>Advanced Menus</h2>
-    <p class="page-desc">Tiered menus, menu bars, panel menus, context menus, docks, and speed dials.</p>
+    <p class="page-desc">Tiered menus, menu bars, panel menus, context menus, tab menus, docks, and speed dials.</p>
+
+    <div class="demo-section">
+      <h3>Tab Menu</h3>
+      <p class="section-desc">Horizontal tab-style navigation. Supports route-based links and command-based actions.</p>
+      <glint-tab-menu [items]="tabMenuItems" />
+      @if (lastAction()['tab']; as action) {
+        <div class="output">Last action: {{ action }}</div>
+      }
+    </div>
 
     <div class="demo-section">
       <h3>Tiered Menu (Inline)</h3>
       <p class="section-desc">Nested menu with submenus that expand on hover or keyboard navigation.</p>
       <glint-tiered-menu [items]="tieredMenuItems" />
-      @if (lastTieredAction) {
-        <div class="output">Last action: {{ lastTieredAction }}</div>
+      @if (lastAction()['tiered']; as action) {
+        <div class="output">Last action: {{ action }}</div>
       }
     </div>
 
@@ -38,8 +50,8 @@ import type { GlintMenuItem } from '@glint-ng/core';
       <h3>Menu Bar</h3>
       <p class="section-desc">Horizontal desktop-style menu bar with dropdown submenus.</p>
       <glint-menubar [items]="menuBarItems" />
-      @if (lastMenuBarAction) {
-        <div class="output">Last action: {{ lastMenuBarAction }}</div>
+      @if (lastAction()['menubar']; as action) {
+        <div class="output">Last action: {{ action }}</div>
       }
     </div>
 
@@ -49,8 +61,8 @@ import type { GlintMenuItem } from '@glint-ng/core';
       <div style="max-inline-size: 20rem;">
         <glint-panel-menu [items]="panelMenuItems" [multiple]="true" />
       </div>
-      @if (lastPanelAction) {
-        <div class="output">Last action: {{ lastPanelAction }}</div>
+      @if (lastAction()['panel']; as action) {
+        <div class="output">Last action: {{ action }}</div>
       }
     </div>
 
@@ -60,8 +72,8 @@ import type { GlintMenuItem } from '@glint-ng/core';
       <div class="context-target" [glintContextMenu]="contextMenuItems">
         Right-click here to open context menu
       </div>
-      @if (lastContextAction) {
-        <div class="output">Last action: {{ lastContextAction }}</div>
+      @if (lastAction()['context']; as action) {
+        <div class="output">Last action: {{ action }}</div>
       }
     </div>
 
@@ -71,8 +83,8 @@ import type { GlintMenuItem } from '@glint-ng/core';
       <div class="row">
         <glint-dock [items]="dockItems" position="bottom" />
       </div>
-      @if (lastDockAction) {
-        <div class="output">Last action: {{ lastDockAction }}</div>
+      @if (lastAction()['dock']; as action) {
+        <div class="output">Last action: {{ action }}</div>
       }
     </div>
 
@@ -105,25 +117,13 @@ import type { GlintMenuItem } from '@glint-ng/core';
           </div>
         </div>
       </div>
-      @if (lastSpeedDialAction) {
-        <div class="output">Last action: {{ lastSpeedDialAction }}</div>
+      @if (lastAction()['speedDial']; as action) {
+        <div class="output">Last action: {{ action }}</div>
       }
     </div>
   `,
   styles: `
     :host { display: block; }
-    h2 { margin-block: 0 0.25rem; font-size: 1.75rem; font-weight: 600; color: #1e293b; }
-    .page-desc { color: #64748b; margin-block: 0 2rem; font-size: 1.25rem; }
-    .demo-section {
-      background: white; border: 1px solid #e2e8f0; border-radius: 0.625rem;
-      padding: 2rem; margin-block-end: 1.5rem;
-    }
-    .demo-section h3 { margin-block: 0 1rem; font-size: 1rem; font-weight: 600; color: #334155; }
-    .section-desc { color: #64748b; font-size: 0.875rem; margin-block: -0.5rem 1rem; }
-    .row { display: flex; gap: 0.75rem; flex-wrap: wrap; align-items: center; }
-    .stack { display: flex; flex-direction: column; gap: 1rem; }
-    .output { margin-block-start: 1rem; padding: 0.75rem 1rem; background: #f8fafc;
-      border: 1px solid #e2e8f0; border-radius: 6px; font-size: 0.875rem; color: #64748b; }
     .context-target {
       display: flex;
       align-items: center;
@@ -181,116 +181,123 @@ import type { GlintMenuItem } from '@glint-ng/core';
   `,
 })
 export class AdvancedMenusDemoComponent {
-  lastTieredAction = '';
-  lastMenuBarAction = '';
-  lastPanelAction = '';
-  lastContextAction = '';
-  lastDockAction = '';
-  lastSpeedDialAction = '';
+  lastAction = signal<Record<string, string>>({});
+
+  private track(section: string, label: string): () => void {
+    return () => this.lastAction.update(a => ({ ...a, [section]: label }));
+  }
+
+  tabMenuItems: GlintMenuItem[] = [
+    { label: 'Overview', icon: 'home', command: this.track('tab', 'Overview') },
+    { label: 'Features', icon: 'star', command: this.track('tab', 'Features') },
+    { label: 'Pricing', icon: 'creditCard', command: this.track('tab', 'Pricing') },
+    { label: 'Documentation', icon: 'fileText', command: this.track('tab', 'Documentation') },
+    { label: 'Support', icon: 'messageCircle', disabled: true },
+  ];
 
   tieredMenuItems: GlintMenuItem[] = [
     {
       label: 'File',
       items: [
-        { label: 'New', command: () => { this.lastTieredAction = 'File > New'; } },
-        { label: 'Open', command: () => { this.lastTieredAction = 'File > Open'; } },
+        { label: 'New', command: this.track('tiered', 'File > New') },
+        { label: 'Open', command: this.track('tiered', 'File > Open') },
         {
           label: 'Export',
           items: [
-            { label: 'PDF', command: () => { this.lastTieredAction = 'File > Export > PDF'; } },
-            { label: 'CSV', command: () => { this.lastTieredAction = 'File > Export > CSV'; } },
-            { label: 'Excel', command: () => { this.lastTieredAction = 'File > Export > Excel'; } },
+            { label: 'PDF', command: this.track('tiered', 'File > Export > PDF') },
+            { label: 'CSV', command: this.track('tiered', 'File > Export > CSV') },
+            { label: 'Excel', command: this.track('tiered', 'File > Export > Excel') },
           ],
         },
-        { label: 'Save', separator: true, command: () => { this.lastTieredAction = 'File > Save'; } },
-        { label: 'Quit', command: () => { this.lastTieredAction = 'File > Quit'; } },
+        { label: 'Save', separator: true, command: this.track('tiered', 'File > Save') },
+        { label: 'Quit', command: this.track('tiered', 'File > Quit') },
       ],
     },
     {
       label: 'Edit',
       items: [
-        { label: 'Undo', command: () => { this.lastTieredAction = 'Edit > Undo'; } },
-        { label: 'Redo', command: () => { this.lastTieredAction = 'Edit > Redo'; } },
-        { label: 'Cut', separator: true, command: () => { this.lastTieredAction = 'Edit > Cut'; } },
-        { label: 'Copy', command: () => { this.lastTieredAction = 'Edit > Copy'; } },
-        { label: 'Paste', command: () => { this.lastTieredAction = 'Edit > Paste'; } },
+        { label: 'Undo', command: this.track('tiered', 'Edit > Undo') },
+        { label: 'Redo', command: this.track('tiered', 'Edit > Redo') },
+        { label: 'Cut', separator: true, command: this.track('tiered', 'Edit > Cut') },
+        { label: 'Copy', command: this.track('tiered', 'Edit > Copy') },
+        { label: 'Paste', command: this.track('tiered', 'Edit > Paste') },
       ],
     },
     {
       label: 'View',
       items: [
-        { label: 'Zoom In', command: () => { this.lastTieredAction = 'View > Zoom In'; } },
-        { label: 'Zoom Out', command: () => { this.lastTieredAction = 'View > Zoom Out'; } },
-        { label: 'Full Screen', command: () => { this.lastTieredAction = 'View > Full Screen'; } },
+        { label: 'Zoom In', command: this.track('tiered', 'View > Zoom In') },
+        { label: 'Zoom Out', command: this.track('tiered', 'View > Zoom Out') },
+        { label: 'Full Screen', command: this.track('tiered', 'View > Full Screen') },
       ],
     },
-    { label: 'Help', command: () => { this.lastTieredAction = 'Help'; } },
+    { label: 'Help', command: this.track('tiered', 'Help') },
   ];
 
   menuBarItems: GlintMenuItem[] = [
     {
       label: 'File',
       items: [
-        { label: 'New Project', command: () => { this.lastMenuBarAction = 'File > New Project'; } },
-        { label: 'Open Project', command: () => { this.lastMenuBarAction = 'File > Open Project'; } },
-        { label: 'Save', command: () => { this.lastMenuBarAction = 'File > Save'; } },
-        { label: 'Save As...', command: () => { this.lastMenuBarAction = 'File > Save As'; } },
-        { label: 'Exit', separator: true, command: () => { this.lastMenuBarAction = 'File > Exit'; } },
+        { label: 'New Project', command: this.track('menubar', 'File > New Project') },
+        { label: 'Open Project', command: this.track('menubar', 'File > Open Project') },
+        { label: 'Save', command: this.track('menubar', 'File > Save') },
+        { label: 'Save As...', command: this.track('menubar', 'File > Save As') },
+        { label: 'Exit', separator: true, command: this.track('menubar', 'File > Exit') },
       ],
     },
     {
       label: 'Edit',
       items: [
-        { label: 'Undo', command: () => { this.lastMenuBarAction = 'Edit > Undo'; } },
-        { label: 'Redo', command: () => { this.lastMenuBarAction = 'Edit > Redo'; } },
-        { label: 'Find & Replace', separator: true, command: () => { this.lastMenuBarAction = 'Edit > Find & Replace'; } },
-        { label: 'Preferences', command: () => { this.lastMenuBarAction = 'Edit > Preferences'; } },
+        { label: 'Undo', command: this.track('menubar', 'Edit > Undo') },
+        { label: 'Redo', command: this.track('menubar', 'Edit > Redo') },
+        { label: 'Find & Replace', separator: true, command: this.track('menubar', 'Edit > Find & Replace') },
+        { label: 'Preferences', command: this.track('menubar', 'Edit > Preferences') },
       ],
     },
     {
       label: 'View',
       items: [
-        { label: 'Sidebar', command: () => { this.lastMenuBarAction = 'View > Sidebar'; } },
-        { label: 'Terminal', command: () => { this.lastMenuBarAction = 'View > Terminal'; } },
-        { label: 'Status Bar', command: () => { this.lastMenuBarAction = 'View > Status Bar'; } },
+        { label: 'Sidebar', command: this.track('menubar', 'View > Sidebar') },
+        { label: 'Terminal', command: this.track('menubar', 'View > Terminal') },
+        { label: 'Status Bar', command: this.track('menubar', 'View > Status Bar') },
       ],
     },
     {
       label: 'Build',
       items: [
-        { label: 'Build Project', command: () => { this.lastMenuBarAction = 'Build > Build Project'; } },
-        { label: 'Clean Build', command: () => { this.lastMenuBarAction = 'Build > Clean Build'; } },
-        { label: 'Run Tests', command: () => { this.lastMenuBarAction = 'Build > Run Tests'; } },
+        { label: 'Build Project', command: this.track('menubar', 'Build > Build Project') },
+        { label: 'Clean Build', command: this.track('menubar', 'Build > Clean Build') },
+        { label: 'Run Tests', command: this.track('menubar', 'Build > Run Tests') },
       ],
     },
-    { label: 'Help', command: () => { this.lastMenuBarAction = 'Help'; } },
+    { label: 'Help', command: this.track('menubar', 'Help') },
   ];
 
   panelMenuItems: GlintMenuItem[] = [
     {
       label: 'Dashboard',
       items: [
-        { label: 'Analytics', command: () => { this.lastPanelAction = 'Dashboard > Analytics'; } },
-        { label: 'Reports', command: () => { this.lastPanelAction = 'Dashboard > Reports'; } },
-        { label: 'Real-time', command: () => { this.lastPanelAction = 'Dashboard > Real-time'; } },
+        { label: 'Analytics', command: this.track('panel', 'Dashboard > Analytics') },
+        { label: 'Reports', command: this.track('panel', 'Dashboard > Reports') },
+        { label: 'Real-time', command: this.track('panel', 'Dashboard > Real-time') },
       ],
     },
     {
       label: 'Users',
       items: [
-        { label: 'All Users', command: () => { this.lastPanelAction = 'Users > All Users'; } },
-        { label: 'Roles & Permissions', command: () => { this.lastPanelAction = 'Users > Roles & Permissions'; } },
-        { label: 'Invite User', command: () => { this.lastPanelAction = 'Users > Invite User'; } },
-        { label: 'Activity Log', command: () => { this.lastPanelAction = 'Users > Activity Log'; } },
+        { label: 'All Users', command: this.track('panel', 'Users > All Users') },
+        { label: 'Roles & Permissions', command: this.track('panel', 'Users > Roles & Permissions') },
+        { label: 'Invite User', command: this.track('panel', 'Users > Invite User') },
+        { label: 'Activity Log', command: this.track('panel', 'Users > Activity Log') },
       ],
     },
     {
       label: 'Settings',
       items: [
-        { label: 'General', command: () => { this.lastPanelAction = 'Settings > General'; } },
-        { label: 'Security', command: () => { this.lastPanelAction = 'Settings > Security'; } },
-        { label: 'Notifications', command: () => { this.lastPanelAction = 'Settings > Notifications'; } },
-        { label: 'Integrations', command: () => { this.lastPanelAction = 'Settings > Integrations'; } },
+        { label: 'General', command: this.track('panel', 'Settings > General') },
+        { label: 'Security', command: this.track('panel', 'Settings > Security') },
+        { label: 'Notifications', command: this.track('panel', 'Settings > Notifications') },
+        { label: 'Integrations', command: this.track('panel', 'Settings > Integrations') },
       ],
     },
     {
@@ -304,29 +311,29 @@ export class AdvancedMenusDemoComponent {
   ];
 
   contextMenuItems: GlintMenuItem[] = [
-    { label: 'Copy', command: () => { this.lastContextAction = 'Copy'; } },
-    { label: 'Paste', command: () => { this.lastContextAction = 'Paste'; } },
-    { label: 'Cut', separator: true, command: () => { this.lastContextAction = 'Cut'; } },
-    { label: 'Select All', command: () => { this.lastContextAction = 'Select All'; } },
-    { label: 'Inspect Element', separator: true, command: () => { this.lastContextAction = 'Inspect Element'; } },
-    { label: 'Delete', command: () => { this.lastContextAction = 'Delete'; } },
+    { label: 'Copy', command: this.track('context', 'Copy') },
+    { label: 'Paste', command: this.track('context', 'Paste') },
+    { label: 'Cut', separator: true, command: this.track('context', 'Cut') },
+    { label: 'Select All', command: this.track('context', 'Select All') },
+    { label: 'Inspect Element', separator: true, command: this.track('context', 'Inspect Element') },
+    { label: 'Delete', command: this.track('context', 'Delete') },
   ];
 
   dockItems: GlintMenuItem[] = [
-    { label: 'Finder', icon: '\uD83D\uDCC1', command: () => { this.lastDockAction = 'Finder'; } },
-    { label: 'Terminal', icon: '\uD83D\uDDA5\uFE0F', command: () => { this.lastDockAction = 'Terminal'; } },
-    { label: 'Browser', icon: '\uD83C\uDF10', command: () => { this.lastDockAction = 'Browser'; } },
-    { label: 'Mail', icon: '\u2709\uFE0F', command: () => { this.lastDockAction = 'Mail'; } },
-    { label: 'Calendar', icon: '\uD83D\uDCC5', command: () => { this.lastDockAction = 'Calendar'; } },
-    { label: 'Music', icon: '\uD83C\uDFB5', command: () => { this.lastDockAction = 'Music'; } },
-    { label: 'Photos', icon: '\uD83D\uDDBC\uFE0F', command: () => { this.lastDockAction = 'Photos'; } },
-    { label: 'Settings', icon: '\u2699\uFE0F', command: () => { this.lastDockAction = 'Settings'; } },
+    { label: 'Finder', icon: '📁', command: this.track('dock', 'Finder') },
+    { label: 'Terminal', icon: '🖥️', command: this.track('dock', 'Terminal') },
+    { label: 'Browser', icon: '🌐', command: this.track('dock', 'Browser') },
+    { label: 'Mail', icon: '✉️', command: this.track('dock', 'Mail') },
+    { label: 'Calendar', icon: '📅', command: this.track('dock', 'Calendar') },
+    { label: 'Music', icon: '🎵', command: this.track('dock', 'Music') },
+    { label: 'Photos', icon: '🖼️', command: this.track('dock', 'Photos') },
+    { label: 'Settings', icon: '⚙️', command: this.track('dock', 'Settings') },
   ];
 
   speedDialItems: GlintMenuItem[] = [
-    { label: 'Add', icon: '\u2795', command: () => { this.lastSpeedDialAction = 'Add'; } },
-    { label: 'Edit', icon: '\u270F\uFE0F', command: () => { this.lastSpeedDialAction = 'Edit'; } },
-    { label: 'Share', icon: '\uD83D\uDD17', command: () => { this.lastSpeedDialAction = 'Share'; } },
-    { label: 'Delete', icon: '\uD83D\uDDD1\uFE0F', command: () => { this.lastSpeedDialAction = 'Delete'; } },
+    { label: 'Add', icon: '➕', command: this.track('speedDial', 'Add') },
+    { label: 'Edit', icon: '✏️', command: this.track('speedDial', 'Edit') },
+    { label: 'Share', icon: '🔗', command: this.track('speedDial', 'Share') },
+    { label: 'Delete', icon: '🗑️', command: this.track('speedDial', 'Delete') },
   ];
 }

--- a/apps/demo/src/app/pages/advanced-selects-demo.component.ts
+++ b/apps/demo/src/app/pages/advanced-selects-demo.component.ts
@@ -6,6 +6,7 @@ import {
   GlintCascadeSelectComponent,
   GlintTreeSelectComponent,
   GlintDatepickerComponent,
+  GlintDatepickerDayDirective,
   GlintColorPickerComponent,
 } from '@glint-ng/core';
 import type { GlintMenuItem, GlintTreeNode } from '@glint-ng/core';
@@ -21,28 +22,27 @@ import type { GlintMenuItem, GlintTreeNode } from '@glint-ng/core';
     GlintCascadeSelectComponent,
     GlintTreeSelectComponent,
     GlintDatepickerComponent,
+    GlintDatepickerDayDirective,
     GlintColorPickerComponent,
   ],
+  host: { class: 'demo-page' },
   styles: `
     :host { display: block; }
-    h2 { margin-block: 0 0.25rem; font-size: 1.75rem; font-weight: 600; color: #1e293b; }
-    .page-desc { color: #64748b; margin-block: 0 2rem; font-size: 1.25rem; }
-    .demo-section {
-      background: white; border: 1px solid #e2e8f0; border-radius: 0.625rem;
-      padding: 2rem; margin-block-end: 1.5rem;
-    }
-    .demo-section h3 { margin-block: 0 1rem; font-size: 1rem; font-weight: 600; color: #334155; }
-    .row { display: flex; gap: 0.75rem; flex-wrap: wrap; align-items: center; }
-    .stack { display: flex; flex-direction: column; gap: 1rem; }
-    .output { margin-block-start: 1rem; padding: 0.75rem 1rem; background: #f8fafc;
-      border: 1px solid #e2e8f0; border-radius: 6px; font-size: 0.875rem; color: #64748b; }
-    .label-text {
-      margin-block: 0 0.25rem; font-size: 0.875rem; font-weight: 500; color: #475569;
-    }
     .color-preview {
       display: inline-block; inline-size: 1.25rem; block-size: 1.25rem;
       border-radius: 4px; border: 1px solid #e2e8f0; vertical-align: middle;
       margin-inline-end: 0.5rem;
+    }
+    .custom-day {
+      display: inline-flex; align-items: center; justify-content: center;
+      inline-size: 2rem; block-size: 2rem; border-radius: 50%; font-size: 0.8125rem;
+    }
+    .custom-day--today {
+      background: #3b82f6; color: white; font-weight: 700;
+    }
+    .custom-day--other { opacity: 0.35; }
+    .custom-day--selected:not(.custom-day--today) {
+      outline: 2px solid #3b82f6; outline-offset: -2px;
     }
   `,
   template: `
@@ -134,6 +134,25 @@ import type { GlintMenuItem, GlintTreeNode } from '@glint-ng/core';
             [formControl]="dateCtrl"
           />
           <div class="output">Value: {{ formatDate(dateCtrl.value) }}</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ── Datepicker Custom Day Template ───────────── -->
+    <div class="demo-section">
+      <h3>Datepicker — Custom Day Template</h3>
+      <p class="section-desc">Use the <code>glintDatepickerDay</code> structural directive to render custom day cells. This example highlights today and dims other-month days.</p>
+
+      <div class="stack">
+        <div>
+          <glint-datepicker placeholder="Custom day cells" [formControl]="customDayCtrl">
+            <ng-template glintDatepickerDay let-date let-today="today" let-otherMonth="otherMonth" let-selected="selected">
+              <span class="custom-day" [class.custom-day--today]="today" [class.custom-day--other]="otherMonth" [class.custom-day--selected]="selected">
+                {{ date.getDate() }}
+              </span>
+            </ng-template>
+          </glint-datepicker>
+          <div class="output">Value: {{ formatDate(customDayCtrl.value) }}</div>
         </div>
       </div>
     </div>
@@ -346,6 +365,7 @@ export class AdvancedSelectsDemoComponent {
 
   // ── Datepicker ─────────────────────────────────
   dateCtrl = new FormControl<Date | null>(null);
+  customDayCtrl = new FormControl<Date | null>(null);
 
   formatDate(value: unknown): string {
     if (value instanceof Date) {

--- a/apps/demo/src/app/pages/button-demo.component.ts
+++ b/apps/demo/src/app/pages/button-demo.component.ts
@@ -65,19 +65,9 @@ import { GlintButtonComponent, GlintStyleZoneComponent, GlintColor } from '@glin
       </glint-style-zone>
     </div>
   `,
+  host: { class: 'demo-page' },
   styles: `
     :host { display: block; }
-    h2 { margin-block: 0 0.25rem; font-size: 1.75rem; font-weight: 600; color: #1e293b; }
-    .page-desc { color: #64748b; margin-block: 0 2rem; font-size: 1.25rem; }
-    .demo-section {
-      background: white;
-      border: 1px solid #e2e8f0;
-      border-radius: 0.625rem;
-      padding: 2rem;
-      margin-block-end: 1.5rem;
-    }
-    .demo-section h3 { margin-block: 0 1rem; font-size: 1rem; font-weight: 600; color: #334155; }
-    .row { display: flex; gap: 0.75rem; flex-wrap: wrap; align-items: center; }
     .variant-label {
       margin-block: 1.25rem 0.5rem;
       font-size: 0.8125rem;

--- a/apps/demo/src/app/pages/card-demo.component.ts
+++ b/apps/demo/src/app/pages/card-demo.component.ts
@@ -45,19 +45,9 @@ import { GlintCardComponent, GlintCardHeaderDirective, GlintCardFooterDirective,
       </glint-card>
     </div>
   `,
+  host: { class: 'demo-page' },
   styles: `
     :host { display: block; }
-    h2 { margin-block: 0 0.25rem; font-size: 1.75rem; font-weight: 600; color: #1e293b; }
-    .page-desc { color: #64748b; margin-block: 0 2rem; font-size: 1.25rem; }
-    .demo-section {
-      background: white;
-      border: 1px solid #e2e8f0;
-      border-radius: 0.625rem;
-      padding: 2rem;
-      margin-block-end: 1.5rem;
-    }
-    .demo-section h3 { margin-block: 0 1rem; font-size: 1rem; font-weight: 600; color: #334155; }
-    .row { display: flex; gap: 0.75rem; flex-wrap: wrap; align-items: center; }
     .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1rem; }
     p { margin: 0.5rem 0; color: #475569; line-height: 1.5; }
   `,

--- a/apps/demo/src/app/pages/containers-demo.component.ts
+++ b/apps/demo/src/app/pages/containers-demo.component.ts
@@ -81,21 +81,9 @@ import {
       }
     </div>
   `,
+  host: { class: 'demo-page' },
   styles: `
     :host { display: block; }
-    h2 { margin-block: 0 0.25rem; font-size: 1.75rem; font-weight: 600; color: #1e293b; }
-    .page-desc { color: #64748b; margin-block: 0 2rem; font-size: 1.25rem; }
-    .demo-section {
-      background: white;
-      border: 1px solid #e2e8f0;
-      border-radius: 0.625rem;
-      padding: 2rem;
-      margin-block-end: 1.5rem;
-    }
-    .demo-section h3 { margin-block: 0 1rem; font-size: 1rem; font-weight: 600; color: #334155; }
-    .row { display: flex; gap: 0.75rem; flex-wrap: wrap; align-items: center; }
-    .stack { display: flex; flex-direction: column; gap: 1rem; }
-    .output { margin-block-start: 1rem; padding: 0.75rem 1rem; background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 6px; font-size: 0.875rem; color: #64748b; }
     .popover-text { margin: 0; line-height: 1.5; }
     .toolbar-title { font-weight: 600; font-size: 1rem; }
     p { color: #475569; margin-block: 0.25rem; line-height: 1.5; }

--- a/apps/demo/src/app/pages/data-display-demo.component.ts
+++ b/apps/demo/src/app/pages/data-display-demo.component.ts
@@ -110,20 +110,9 @@ import {
       </div>
     </div>
   `,
+  host: { class: 'demo-page' },
   styles: `
     :host { display: block; }
-    h2 { margin-block: 0 0.25rem; font-size: 1.75rem; font-weight: 600; color: #1e293b; }
-    .page-desc { color: #64748b; margin-block: 0 2rem; font-size: 1.25rem; }
-    .demo-section {
-      background: white;
-      border: 1px solid #e2e8f0;
-      border-radius: 0.625rem;
-      padding: 2rem;
-      margin-block-end: 1.5rem;
-    }
-    .demo-section h3 { margin-block: 0 1rem; font-size: 1rem; font-weight: 600; color: #334155; }
-    .row { display: flex; gap: 0.75rem; flex-wrap: wrap; align-items: center; }
-    .stack { display: flex; flex-direction: column; gap: 1rem; }
     .sub-heading { margin-block: 1.5rem 1rem; }
   `,
 })

--- a/apps/demo/src/app/pages/dialog-demo.component.ts
+++ b/apps/demo/src/app/pages/dialog-demo.component.ts
@@ -47,20 +47,9 @@ class SampleDialogComponent {
       }
     </div>
   `,
+  host: { class: 'demo-page' },
   styles: `
     :host { display: block; }
-    h2 { margin-block: 0 0.25rem; font-size: 1.75rem; font-weight: 600; color: #1e293b; }
-    .page-desc { color: #64748b; margin-block: 0 2rem; font-size: 1.25rem; }
-    .demo-section {
-      background: white;
-      border: 1px solid #e2e8f0;
-      border-radius: 0.625rem;
-      padding: 2rem;
-      margin-block-end: 1.5rem;
-    }
-    .demo-section h3 { margin-block: 0 1rem; font-size: 1rem; font-weight: 600; color: #334155; }
-    .row { display: flex; gap: 0.75rem; flex-wrap: wrap; align-items: center; }
-    .output { margin-block-start: 1rem; padding: 0.75rem 1rem; background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 6px; font-size: 0.875rem; color: #64748b; }
   `,
 })
 export class DialogDemoComponent {

--- a/apps/demo/src/app/pages/divider-demo.component.ts
+++ b/apps/demo/src/app/pages/divider-demo.component.ts
@@ -32,20 +32,9 @@ import { GlintDividerComponent } from '@glint-ng/core';
       </div>
     </div>
   `,
+  host: { class: 'demo-page' },
   styles: `
     :host { display: block; }
-    h2 { margin-block: 0 0.25rem; font-size: 1.75rem; font-weight: 600; color: #1e293b; }
-    .page-desc { color: #64748b; margin-block: 0 2rem; font-size: 1.25rem; }
-    .demo-section {
-      background: white;
-      border: 1px solid #e2e8f0;
-      border-radius: 0.625rem;
-      padding: 2rem;
-      margin-block-end: 1.5rem;
-    }
-    .demo-section h3 { margin-block: 0 1rem; font-size: 1rem; font-weight: 600; color: #334155; }
-    .row { display: flex; gap: 0.75rem; flex-wrap: wrap; align-items: center; }
-    .stack { display: flex; flex-direction: column; gap: 1rem; }
     .vertical-row {
       display: flex;
       align-items: center;

--- a/apps/demo/src/app/pages/feedback-demo.component.ts
+++ b/apps/demo/src/app/pages/feedback-demo.component.ts
@@ -76,20 +76,9 @@ import {
       </div>
     </div>
   `,
+  host: { class: 'demo-page' },
   styles: `
     :host { display: block; }
-    h2 { margin-block: 0 0.25rem; font-size: 1.75rem; font-weight: 600; color: #1e293b; }
-    .page-desc { color: #64748b; margin-block: 0 2rem; font-size: 1.25rem; }
-    .demo-section {
-      background: white;
-      border: 1px solid #e2e8f0;
-      border-radius: 0.625rem;
-      padding: 2rem;
-      margin-block-end: 1.5rem;
-    }
-    .demo-section h3 { margin-block: 0 1rem; font-size: 1rem; font-weight: 600; color: #334155; }
-    .row { display: flex; gap: 0.75rem; flex-wrap: wrap; align-items: center; }
-    .stack { display: flex; flex-direction: column; gap: 1rem; }
   `,
 })
 export class FeedbackDemoComponent {}

--- a/apps/demo/src/app/pages/form-controls-demo.component.ts
+++ b/apps/demo/src/app/pages/form-controls-demo.component.ts
@@ -73,32 +73,9 @@ import {
       </div>
     </div>
   `,
+  host: { class: 'demo-page' },
   styles: `
     :host { display: block; }
-    h2 { margin-block: 0 0.25rem; font-size: 1.75rem; font-weight: 600; color: #1e293b; }
-    .page-desc { color: #64748b; margin-block: 0 2rem; font-size: 1.25rem; }
-    .demo-section {
-      background: white;
-      border: 1px solid #e2e8f0;
-      border-radius: 0.625rem;
-      padding: 2rem;
-      margin-block-end: 1.5rem;
-    }
-    .demo-section h3 { margin-block: 0 1rem; font-size: 1rem; font-weight: 600; color: #334155; }
-    .row { display: flex; gap: 0.75rem; flex-wrap: wrap; align-items: center; }
-    .stack { display: flex; flex-direction: column; gap: 1rem; }
-    .value-display {
-      margin-block: 0.75rem 0;
-      font-size: 0.8125rem;
-      color: #64748b;
-      font-family: monospace;
-    }
-    .label-text {
-      margin-block: 0 0.25rem;
-      font-size: 0.875rem;
-      font-weight: 500;
-      color: #475569;
-    }
   `,
 })
 export class FormControlsDemoComponent {

--- a/apps/demo/src/app/pages/icons-demo.component.ts
+++ b/apps/demo/src/app/pages/icons-demo.component.ts
@@ -174,22 +174,9 @@ provideGlintIcons(mapIcons(heroicons, myHeroConverter))
 provideGlintIcons({{ '{' }} logo: '&lt;svg&gt;...&lt;/svg&gt;' {{ '}' }})</pre>
     </div>
   `,
+  host: { class: 'demo-page' },
   styles: `
     :host { display: block; }
-    h2 { margin-block: 0 0.25rem; font-size: 1.75rem; font-weight: 600; color: #1e293b; }
-    .page-desc { color: #64748b; margin-block: 0 2rem; font-size: 1.25rem; }
-    .demo-section {
-      background: white;
-      border: 1px solid #e2e8f0;
-      border-radius: 0.625rem;
-      padding: 2rem;
-      margin-block-end: 1.5rem;
-    }
-    .demo-section h3 { margin-block: 0 1rem; font-size: 1rem; font-weight: 600; color: #334155; }
-    .section-desc { color: #64748b; margin-block: -0.5rem 1rem; font-size: 0.875rem; }
-    .row { display: flex; gap: 0.75rem; flex-wrap: wrap; align-items: center; }
-    code { background: #f1f5f9; padding: 0.125rem 0.375rem; border-radius: 0.25rem; font-size: 0.8125rem; }
-
     .icon-grid {
       display: grid;
       grid-template-columns: repeat(auto-fill, minmax(7.5rem, 1fr));

--- a/apps/demo/src/app/pages/input-demo.component.ts
+++ b/apps/demo/src/app/pages/input-demo.component.ts
@@ -41,19 +41,9 @@ import { GlintInputComponent } from '@glint-ng/core';
       </div>
     </div>
   `,
+  host: { class: 'demo-page' },
   styles: `
     :host { display: block; }
-    h2 { margin-block: 0 0.25rem; font-size: 1.75rem; font-weight: 600; color: #1e293b; }
-    .page-desc { color: #64748b; margin-block: 0 2rem; font-size: 1.25rem; }
-    .demo-section {
-      background: white;
-      border: 1px solid #e2e8f0;
-      border-radius: 0.625rem;
-      padding: 2rem;
-      margin-block-end: 1.5rem;
-    }
-    .demo-section h3 { margin-block: 0 1rem; font-size: 1rem; font-weight: 600; color: #334155; }
-    .row { display: flex; gap: 0.75rem; flex-wrap: wrap; align-items: center; }
     .stack { display: flex; flex-direction: column; gap: 1rem; max-inline-size: 400px; }
     .output { margin-block-start: 0.75rem; font-size: 0.875rem; color: #64748b; }
   `,

--- a/apps/demo/src/app/pages/lists-demo.component.ts
+++ b/apps/demo/src/app/pages/lists-demo.component.ts
@@ -15,6 +15,7 @@ interface Product {
 @Component({
   selector: 'glint-lists-demo',
   standalone: true,
+  host: { class: 'demo-page' },
   imports: [
     GlintDataViewComponent,
     GlintOrderListComponent,
@@ -101,18 +102,6 @@ interface Product {
   `,
   styles: `
     :host { display: block; }
-    h2 { margin-block: 0 0.25rem; font-size: 1.75rem; font-weight: 600; color: #1e293b; }
-    .page-desc { color: #64748b; margin-block: 0 2rem; font-size: 1.25rem; }
-    .demo-section {
-      background: white; border: 1px solid #e2e8f0; border-radius: 0.625rem;
-      padding: 2rem; margin-block-end: 1.5rem;
-    }
-    .demo-section h3 { margin-block: 0 1rem; font-size: 1rem; font-weight: 600; color: #334155; }
-    .row { display: flex; gap: 0.75rem; flex-wrap: wrap; align-items: center; }
-    .stack { display: flex; flex-direction: column; gap: 1rem; }
-    .output { margin-block-start: 1rem; padding: 0.75rem 1rem; background: #f8fafc;
-      border: 1px solid #e2e8f0; border-radius: 6px; font-size: 0.875rem; color: #64748b; }
-    .section-desc { color: #64748b; margin-block: 0 1rem; font-size: 0.875rem; }
 
     /* DataView list row */
     .dv-list-row {

--- a/apps/demo/src/app/pages/media-demo.component.ts
+++ b/apps/demo/src/app/pages/media-demo.component.ts
@@ -11,6 +11,7 @@ import type { GlintGalleriaImage } from '@glint-ng/core';
   selector: 'glint-media-demo',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
+  host: { class: 'demo-page' },
   imports: [
     GlintImageComponent,
     GlintImageCompareComponent,
@@ -143,18 +144,8 @@ import type { GlintGalleriaImage } from '@glint-ng/core';
   `,
   styles: `
     :host { display: block; }
-    h2 { margin-block: 0 0.25rem; font-size: 1.75rem; font-weight: 600; color: #1e293b; }
-    .page-desc { color: #64748b; margin-block: 0 2rem; font-size: 1.25rem; }
-    .demo-section {
-      background: white; border: 1px solid #e2e8f0; border-radius: 0.625rem;
-      padding: 2rem; margin-block-end: 1.5rem;
-    }
-    .demo-section h3 { margin-block: 0 1rem; font-size: 1rem; font-weight: 600; color: #334155; }
     .section-desc { color: #64748b; font-size: 0.875rem; margin-block: -0.5rem 1rem; }
     .row { display: flex; gap: 1.5rem; flex-wrap: wrap; align-items: flex-start; }
-    .stack { display: flex; flex-direction: column; gap: 1rem; }
-    .output { margin-block-start: 1rem; padding: 0.75rem 1rem; background: #f8fafc;
-      border: 1px solid #e2e8f0; border-radius: 6px; font-size: 0.875rem; color: #64748b; }
 
     .image-card {
       display: flex;

--- a/apps/demo/src/app/pages/navigation-demo.component.ts
+++ b/apps/demo/src/app/pages/navigation-demo.component.ts
@@ -10,6 +10,7 @@ import type { GlintMenuItem, GlintBreadcrumbItem } from '@glint-ng/core';
 @Component({
   selector: 'glint-navigation-demo',
   standalone: true,
+  host: { class: 'demo-page' },
   imports: [
     GlintBreadcrumbComponent,
     GlintMenuComponent,
@@ -48,19 +49,6 @@ import type { GlintMenuItem, GlintBreadcrumbItem } from '@glint-ng/core';
   `,
   styles: `
     :host { display: block; }
-    h2 { margin-block: 0 0.25rem; font-size: 1.75rem; font-weight: 600; color: #1e293b; }
-    .page-desc { color: #64748b; margin-block: 0 2rem; font-size: 1.25rem; }
-    .demo-section {
-      background: white;
-      border: 1px solid #e2e8f0;
-      border-radius: 0.625rem;
-      padding: 2rem;
-      margin-block-end: 1.5rem;
-    }
-    .demo-section h3 { margin-block: 0 1rem; font-size: 1rem; font-weight: 600; color: #334155; }
-    .row { display: flex; gap: 0.75rem; flex-wrap: wrap; align-items: center; }
-    .stack { display: flex; flex-direction: column; gap: 1rem; }
-    .output { margin-block-start: 1rem; padding: 0.75rem 1rem; background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 6px; font-size: 0.875rem; color: #64748b; }
   `,
 })
 export class NavigationDemoComponent {

--- a/apps/demo/src/app/pages/panels-demo.component.ts
+++ b/apps/demo/src/app/pages/panels-demo.component.ts
@@ -27,6 +27,7 @@ import {
     GlintEditorComponent,
     GlintButtonComponent,
   ],
+  host: { class: 'demo-page' },
   template: `
     <h2>Panels &amp; Editors</h2>
     <p class="page-desc">Panel containers, splitters, inline editing, scroll panels, and rich text editing.</p>
@@ -192,18 +193,6 @@ console.log(greeting);</pre>
   `,
   styles: `
     :host { display: block; }
-    h2 { margin-block: 0 0.25rem; font-size: 1.75rem; font-weight: 600; color: #1e293b; }
-    .page-desc { color: #64748b; margin-block: 0 2rem; font-size: 1.25rem; }
-    .demo-section {
-      background: white; border: 1px solid #e2e8f0; border-radius: 0.625rem;
-      padding: 2rem; margin-block-end: 1.5rem;
-    }
-    .demo-section h3 { margin-block: 0 1rem; font-size: 1rem; font-weight: 600; color: #334155; }
-    .row { display: flex; gap: 0.75rem; flex-wrap: wrap; align-items: center; }
-    .stack { display: flex; flex-direction: column; gap: 1rem; }
-    .output { margin-block-start: 1rem; padding: 0.75rem 1rem; background: #f8fafc;
-      border: 1px solid #e2e8f0; border-radius: 6px; font-size: 0.875rem; color: #64748b; }
-    .section-desc { color: #64748b; margin-block: 0 1rem; font-size: 0.875rem; }
 
     p { color: #475569; margin-block: 0.25rem; line-height: 1.5; }
 

--- a/apps/demo/src/app/pages/select-demo.component.ts
+++ b/apps/demo/src/app/pages/select-demo.component.ts
@@ -6,6 +6,7 @@ import { GlintSelectComponent, GlintSelectOptionComponent } from '@glint-ng/core
 @Component({
   selector: 'glint-select-demo',
   standalone: true,
+  host: { class: 'demo-page' },
   imports: [GlintSelectComponent, GlintSelectOptionComponent, ReactiveFormsModule, JsonPipe],
   template: `
     <h2>Select</h2>
@@ -56,17 +57,6 @@ import { GlintSelectComponent, GlintSelectOptionComponent } from '@glint-ng/core
   `,
   styles: `
     :host { display: block; }
-    h2 { margin-block: 0 0.25rem; font-size: 1.75rem; font-weight: 600; color: #1e293b; }
-    .page-desc { color: #64748b; margin-block: 0 2rem; font-size: 1.25rem; }
-    .demo-section {
-      background: white;
-      border: 1px solid #e2e8f0;
-      border-radius: 0.625rem;
-      padding: 2rem;
-      margin-block-end: 1.5rem;
-    }
-    .demo-section h3 { margin-block: 0 1rem; font-size: 1rem; font-weight: 600; color: #334155; }
-    .row { display: flex; gap: 0.75rem; flex-wrap: wrap; align-items: center; }
     .stack { display: flex; flex-direction: column; gap: 1rem; max-inline-size: 400px; }
     .output { margin-block-start: 0.75rem; font-size: 0.875rem; color: #64748b; }
   `,

--- a/apps/demo/src/app/pages/selection-demo.component.ts
+++ b/apps/demo/src/app/pages/selection-demo.component.ts
@@ -12,6 +12,7 @@ import type { SelectButtonOption } from '@glint-ng/core';
   selector: 'glint-selection-demo',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
+  host: { class: 'demo-page' },
   imports: [
     ReactiveFormsModule,
     GlintToggleButtonComponent,
@@ -21,20 +22,6 @@ import type { SelectButtonOption } from '@glint-ng/core';
   ],
   styles: `
     :host { display: block; }
-    h2 { margin-block: 0 0.25rem; font-size: 1.75rem; font-weight: 600; color: #1e293b; }
-    .page-desc { color: #64748b; margin-block: 0 2rem; font-size: 1.25rem; }
-    .demo-section {
-      background: white; border: 1px solid #e2e8f0; border-radius: 0.625rem;
-      padding: 2rem; margin-block-end: 1.5rem;
-    }
-    .demo-section h3 { margin-block: 0 1rem; font-size: 1rem; font-weight: 600; color: #334155; }
-    .row { display: flex; gap: 0.75rem; flex-wrap: wrap; align-items: center; }
-    .stack { display: flex; flex-direction: column; gap: 1rem; }
-    .output { margin-block-start: 1rem; padding: 0.75rem 1rem; background: #f8fafc;
-      border: 1px solid #e2e8f0; border-radius: 6px; font-size: 0.875rem; color: #64748b; }
-    .label-text {
-      margin-block: 0 0.25rem; font-size: 0.875rem; font-weight: 500; color: #475569;
-    }
   `,
   template: `
     <h2>Selection Controls</h2>

--- a/apps/demo/src/app/pages/shell-demo.component.ts
+++ b/apps/demo/src/app/pages/shell-demo.component.ts
@@ -27,6 +27,7 @@ import type { GlintMenuItem } from '@glint-ng/core';
     GlintDividerComponent,
     GlintStyleZoneComponent,
   ],
+  host: { class: 'demo-page' },
   styles: `
     :host { display: block; }
 

--- a/apps/demo/src/app/pages/stepper-timeline-demo.component.ts
+++ b/apps/demo/src/app/pages/stepper-timeline-demo.component.ts
@@ -105,21 +105,9 @@ import type { GlintTimelineEvent } from '@glint-ng/core';
       <glint-timeline [events]="timelineEvents" />
     </div>
   `,
+  host: { class: 'demo-page' },
   styles: `
     :host { display: block; }
-    h2 { margin-block: 0 0.25rem; font-size: 1.75rem; font-weight: 600; color: #1e293b; }
-    .page-desc { color: #64748b; margin-block: 0 2rem; font-size: 1.25rem; }
-    .section-desc { color: #64748b; margin-block: 0 1rem; font-size: 0.875rem; }
-    .demo-section {
-      background: white;
-      border: 1px solid #e2e8f0;
-      border-radius: 0.625rem;
-      padding: 2rem;
-      margin-block-end: 1.5rem;
-    }
-    .demo-section h3 { margin-block: 0 1rem; font-size: 1rem; font-weight: 600; color: #334155; }
-    .row { display: flex; gap: 0.75rem; flex-wrap: wrap; align-items: center; }
-    .stack { display: flex; flex-direction: column; gap: 1rem; }
     .step-actions { display: flex; gap: 0.5rem; margin-block-start: 1rem; }
   `,
 })

--- a/apps/demo/src/app/pages/table-demo.component.ts
+++ b/apps/demo/src/app/pages/table-demo.component.ts
@@ -126,19 +126,9 @@ const USERS: Record<string, unknown>[] = [
       />
     </div>
   `,
+  host: { class: 'demo-page' },
   styles: `
     :host { display: block; }
-    h2 { margin-block: 0 0.25rem; font-size: 1.75rem; font-weight: 600; color: #1e293b; }
-    .page-desc { color: #64748b; margin-block: 0 2rem; font-size: 1.25rem; }
-    .section-desc { color: #64748b; margin-block: 0 1rem; font-size: 0.875rem; }
-    .demo-section {
-      background: white;
-      border: 1px solid #e2e8f0;
-      border-radius: 0.625rem;
-      padding: 2rem;
-      margin-block-end: 1.5rem;
-    }
-    .demo-section h3 { margin-block: 0 1rem; font-size: 1rem; font-weight: 600; color: #334155; }
     .selection-info {
       margin-block-start: 0.75rem;
       font-size: 0.875rem;

--- a/apps/demo/src/app/pages/tabs-demo.component.ts
+++ b/apps/demo/src/app/pages/tabs-demo.component.ts
@@ -45,20 +45,9 @@ import {
       </glint-tabs>
     </div>
   `,
+  host: { class: 'demo-page' },
   styles: `
     :host { display: block; }
-    h2 { margin-block: 0 0.25rem; font-size: 1.75rem; font-weight: 600; color: #1e293b; }
-    .page-desc { color: #64748b; margin-block: 0 2rem; font-size: 1.25rem; }
-    .demo-section {
-      background: white;
-      border: 1px solid #e2e8f0;
-      border-radius: 0.625rem;
-      padding: 2rem;
-      margin-block-end: 1.5rem;
-    }
-    .demo-section h3 { margin-block: 0 1rem; font-size: 1rem; font-weight: 600; color: #334155; }
-    .row { display: flex; gap: 0.75rem; flex-wrap: wrap; align-items: center; }
-    .stack { display: flex; flex-direction: column; gap: 1rem; }
   `,
 })
 export class TabsDemoComponent {}

--- a/apps/demo/src/app/pages/text-inputs-demo.component.ts
+++ b/apps/demo/src/app/pages/text-inputs-demo.component.ts
@@ -52,20 +52,9 @@ import {
       </div>
     </div>
   `,
+  host: { class: 'demo-page' },
   styles: `
     :host { display: block; }
-    h2 { margin-block: 0 0.25rem; font-size: 1.75rem; font-weight: 600; color: #1e293b; }
-    .page-desc { color: #64748b; margin-block: 0 2rem; font-size: 1.25rem; }
-    .demo-section {
-      background: white;
-      border: 1px solid #e2e8f0;
-      border-radius: 0.625rem;
-      padding: 2rem;
-      margin-block-end: 1.5rem;
-    }
-    .demo-section h3 { margin-block: 0 1rem; font-size: 1rem; font-weight: 600; color: #334155; }
-    .row { display: flex; gap: 0.75rem; flex-wrap: wrap; align-items: center; }
-    .stack { display: flex; flex-direction: column; gap: 1rem; }
     .value-display {
       margin-block: 0.25rem 0;
       font-size: 0.8125rem;

--- a/apps/demo/src/app/pages/theme-demo.component.ts
+++ b/apps/demo/src/app/pages/theme-demo.component.ts
@@ -112,19 +112,9 @@ import type { ZoneTheme } from '@glint-ng/core';
       </glint-style-zone>
     </div>
   `,
+  host: { class: 'demo-page' },
   styles: `
     :host { display: block; }
-    h2 { margin-block: 0 0.25rem; font-size: 1.75rem; font-weight: 600; color: #1e293b; }
-    .page-desc { color: #64748b; margin-block: 0 2rem; font-size: 1.25rem; }
-    .demo-section {
-      background: white;
-      border: 1px solid #e2e8f0;
-      border-radius: 0.625rem;
-      padding: 2rem;
-      margin-block-end: 1.5rem;
-    }
-    .demo-section h3 { margin-block: 0 1rem; font-size: 1rem; font-weight: 600; color: #334155; }
-    .row { display: flex; gap: 0.75rem; flex-wrap: wrap; align-items: center; }
     p { margin: 0.25rem 0 1rem; color: #475569; font-size: 0.875rem; line-height: 1.5; }
   `,
 })

--- a/apps/demo/src/app/pages/toast-demo.component.ts
+++ b/apps/demo/src/app/pages/toast-demo.component.ts
@@ -9,6 +9,7 @@ import {
   selector: 'glint-toast-demo',
   standalone: true,
   imports: [GlintToastComponent, GlintButtonComponent],
+  host: { class: 'demo-page' },
   template: `
     <h2>Toast</h2>
     <p class="page-desc">Toast notifications for transient feedback messages.</p>
@@ -42,18 +43,6 @@ import {
   `,
   styles: `
     :host { display: block; }
-    h2 { margin-block: 0 0.25rem; font-size: 1.75rem; font-weight: 600; color: #1e293b; }
-    .page-desc { color: #64748b; margin-block: 0 2rem; font-size: 1.25rem; }
-    .demo-section {
-      background: white;
-      border: 1px solid #e2e8f0;
-      border-radius: 0.625rem;
-      padding: 2rem;
-      margin-block-end: 1.5rem;
-    }
-    .demo-section h3 { margin-block: 0 1rem; font-size: 1rem; font-weight: 600; color: #334155; }
-    .row { display: flex; gap: 0.75rem; flex-wrap: wrap; align-items: center; }
-    .stack { display: flex; flex-direction: column; gap: 1rem; }
     .hint { margin-block-start: 1rem; color: #64748b; font-size: 0.875rem; }
   `,
 })

--- a/apps/demo/src/app/pages/tooltip-demo.component.ts
+++ b/apps/demo/src/app/pages/tooltip-demo.component.ts
@@ -5,6 +5,7 @@ import { GlintButtonComponent, GlintTooltipDirective } from '@glint-ng/core';
   selector: 'glint-tooltip-demo',
   standalone: true,
   imports: [GlintButtonComponent, GlintTooltipDirective],
+  host: { class: 'demo-page' },
   template: `
     <h2>Tooltip</h2>
     <p class="page-desc">Tooltips display brief informational text on hover or focus.</p>
@@ -28,19 +29,7 @@ import { GlintButtonComponent, GlintTooltipDirective } from '@glint-ng/core';
   `,
   styles: `
     :host { display: block; }
-    h2 { margin-block: 0 0.25rem; font-size: 1.75rem; font-weight: 600; color: #1e293b; }
-    .page-desc { color: #64748b; margin-block: 0 2rem; font-size: 1.25rem; }
-    .demo-section {
-      background: white;
-      border: 1px solid #e2e8f0;
-      border-radius: 0.625rem;
-      padding: 2rem;
-      margin-block-end: 1.5rem;
-    }
-    .demo-section h3 { margin-block: 0 1rem; font-size: 1rem; font-weight: 600; color: #334155; }
-    .row { display: flex; gap: 0.75rem; flex-wrap: wrap; align-items: center; }
     .hint { margin-block-start: 1rem; color: #64748b; font-size: 0.875rem; }
-    code { background: #f1f5f9; padding: 0.125rem 0.375rem; border-radius: 4px; font-size: 0.8125rem; }
   `,
 })
 export class TooltipDemoComponent {}

--- a/apps/demo/src/app/pages/trees-demo.component.ts
+++ b/apps/demo/src/app/pages/trees-demo.component.ts
@@ -17,6 +17,7 @@ import type { GlintTreeNode } from '@glint-ng/core';
     GlintTreeTableColumnDirective,
     GlintOrganizationChartComponent,
   ],
+  host: { class: 'demo-page' },
   template: `
     <h2>Trees</h2>
     <p class="page-desc">Hierarchical tree views, tree tables, and organization charts.</p>
@@ -95,18 +96,6 @@ import type { GlintTreeNode } from '@glint-ng/core';
   `,
   styles: `
     :host { display: block; }
-    h2 { margin-block: 0 0.25rem; font-size: 1.75rem; font-weight: 600; color: #1e293b; }
-    .page-desc { color: #64748b; margin-block: 0 2rem; font-size: 1.25rem; }
-    .demo-section {
-      background: white; border: 1px solid #e2e8f0; border-radius: 0.625rem;
-      padding: 2rem; margin-block-end: 1.5rem;
-    }
-    .demo-section h3 { margin-block: 0 1rem; font-size: 1rem; font-weight: 600; color: #334155; }
-    .section-desc { color: #64748b; font-size: 0.875rem; margin-block: -0.5rem 1rem; }
-    .row { display: flex; gap: 0.75rem; flex-wrap: wrap; align-items: center; }
-    .stack { display: flex; flex-direction: column; gap: 1rem; }
-    .output { margin-block-start: 1rem; padding: 0.75rem 1rem; background: #f8fafc;
-      border: 1px solid #e2e8f0; border-radius: 6px; font-size: 0.875rem; color: #64748b; }
   `,
 })
 export class TreesDemoComponent {

--- a/apps/demo/src/app/pages/utilities-demo.component.ts
+++ b/apps/demo/src/app/pages/utilities-demo.component.ts
@@ -21,6 +21,7 @@ import type { GlintMeterItem } from '@glint-ng/core';
     GlintFileUploadComponent,
     GlintButtonComponent,
   ],
+  host: { class: 'demo-page' },
   template: `
     <h2>Utilities</h2>
     <p class="page-desc">Utility components for scroll-to-top, meters, blocking UI, badges, confirmations, and file uploads.</p>
@@ -136,18 +137,6 @@ import type { GlintMeterItem } from '@glint-ng/core';
   `,
   styles: `
     :host { display: block; }
-    h2 { margin-block: 0 0.25rem; font-size: 1.75rem; font-weight: 600; color: #1e293b; }
-    .page-desc { color: #64748b; margin-block: 0 2rem; font-size: 1.25rem; }
-    .demo-section {
-      background: white; border: 1px solid #e2e8f0; border-radius: 0.625rem;
-      padding: 2rem; margin-block-end: 1.5rem;
-    }
-    .demo-section h3 { margin-block: 0 1rem; font-size: 1rem; font-weight: 600; color: #334155; }
-    .row { display: flex; gap: 0.75rem; flex-wrap: wrap; align-items: center; }
-    .stack { display: flex; flex-direction: column; gap: 1rem; }
-    .output { margin-block-start: 1rem; padding: 0.75rem 1rem; background: #f8fafc;
-      border: 1px solid #e2e8f0; border-radius: 6px; font-size: 0.875rem; color: #64748b; }
-    .section-desc { color: #64748b; margin-block: 0 1rem; font-size: 0.875rem; }
 
     p { color: #475569; margin-block: 0.25rem; line-height: 1.5; }
 

--- a/apps/demo/src/styles.scss
+++ b/apps/demo/src/styles.scss
@@ -18,3 +18,82 @@ body {
   background: #f8fafc;
   -webkit-font-smoothing: antialiased;
 }
+
+/* ── Shared demo page styles ────────────────────── */
+.demo-page > h2 {
+  margin-block: 0 0.25rem;
+  font-size: 1.75rem;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.demo-page > .page-desc {
+  color: #64748b;
+  margin-block: 0 2rem;
+  font-size: 1.25rem;
+}
+
+.demo-section {
+  background: white;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.625rem;
+  padding: 2rem;
+  margin-block-end: 1.5rem;
+}
+
+.demo-section h3 {
+  margin-block: 0 1rem;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #334155;
+}
+
+.section-desc {
+  color: #64748b;
+  font-size: 0.875rem;
+  margin-block: -0.5rem 1rem;
+}
+
+.row {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.stack {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.output {
+  margin-block-start: 1rem;
+  padding: 0.75rem 1rem;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  color: #64748b;
+}
+
+.label-text {
+  margin-block: 0 0.25rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #475569;
+}
+
+.value-display {
+  margin-block: 0.75rem 0;
+  font-size: 0.8125rem;
+  color: #64748b;
+  font-family: monospace;
+}
+
+code {
+  background: #f1f5f9;
+  padding: 0.125rem 0.375rem;
+  border-radius: 4px;
+  font-size: 0.8125rem;
+}

--- a/libs/ui/README.md
+++ b/libs/ui/README.md
@@ -52,6 +52,39 @@ export class AppComponent {
 }
 ```
 
+## Replacing Native `confirm()`
+
+Use `GlintConfirmDialogService` for styled, async confirmation dialogs that inherit your theme:
+
+```typescript
+// Before — native confirm()
+if (confirm('Delete this item?')) {
+  this.delete(item);
+}
+
+// After — GlintConfirmDialogService
+import { GlintConfirmDialogService } from '@glint-ng/core';
+
+export class MyComponent {
+  private confirmDialog = inject(GlintConfirmDialogService);
+
+  async onDelete(item: Item): Promise<void> {
+    const confirmed = await this.confirmDialog.confirm({
+      header: 'Confirm Deletion',
+      message: 'Are you sure you want to delete this item?',
+      acceptLabel: 'Delete',
+      rejectLabel: 'Cancel',
+      severity: 'danger',
+    });
+    if (confirmed) {
+      this.delete(item);
+    }
+  }
+}
+```
+
+The service returns a `Promise<boolean>` — no callbacks needed.
+
 ## Theming with Style Zones
 
 Wrap any section of your app in a `<glint-style-zone>` to override theme tokens. Zones nest and inherit:
@@ -123,7 +156,7 @@ Then use them by name:
 |----------|-----------|
 | **Form** | Input, InputNumber, Textarea, Password, Select, MultiSelect, Checkbox, RadioButton, ToggleSwitch, ToggleButton, SelectButton, Slider, Knob, Rating, ColorPicker, DatePicker, AutoComplete, CascadeSelect, TreeSelect, InputMask, InputOTP, FileUpload, FloatLabel, InputGroup, ListBox |
 | **Data** | Table, TreeTable, DataView, Tree, OrganizationChart, Scroller, Timeline, Avatar, Badge, Tag, Chip, Card, Carousel, Galleria, Image, ImageCompare, MeterGroup |
-| **Navigation** | Menu, MenuBar, TieredMenu, ContextMenu, PanelMenu, Breadcrumb, Paginator, Dock, SpeedDial, SplitButton, Tabs, Stepper |
+| **Navigation** | Menu, MenuBar, TieredMenu, ContextMenu, PanelMenu, TabMenu, Breadcrumb, Paginator, Dock, SpeedDial, SplitButton, Tabs, Stepper |
 | **Overlay** | Dialog, ConfirmDialog, ConfirmPopup, Drawer, Popover, Tooltip, OverlayBadge |
 | **Feedback** | Toast, Message, ProgressBar, ProgressSpinner, Skeleton, BlockUI |
 | **Layout** | Shell, Divider, Splitter, ScrollPanel, Panel, Fieldset, Accordion, Toolbar, Inplace, ScrollTop |


### PR DESCRIPTION
## Summary
- Add **"Replacing native `confirm()`"** migration guide to README with async/await pattern (Closes #47)
- Add **TabMenu** demo section to Advanced Menus page + catalog entry
- Add **DatepickerDay** custom template demo to Advanced Selects page
- Extract shared demo styles to global `styles.scss`, removing ~450 duplicated CSS lines across 30 components
- Consolidate `lastXAction` fields into `signal<Record>` + `track()` helper in advanced-menus-demo

🤖 Generated with [Claude Code](https://claude.com/claude-code)